### PR TITLE
Add typings to export field

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
     "./nuxt": {
+      "types": "./dist/nuxt.d.ts",
       "require": "./dist/nuxt.cjs",
       "import": "./dist/nuxt.mjs"
     }


### PR DESCRIPTION
This is related to https://github.com/vueuse/motion/issues/118

Turns out that the typings field is no longer being used when an exports field is defined.

source: https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts